### PR TITLE
URLs instead of IDs

### DIFF
--- a/addons/SvgOutput/SvgOutputTags.php
+++ b/addons/SvgOutput/SvgOutputTags.php
@@ -9,7 +9,7 @@ class SvgOutputTags extends Tags
 {
     public function index()
     {
-        $asset = Asset::find($this->get('id'));
+        $asset = Asset::find($this->get('url'));
         $class = $this->get('class');
         $svg = $asset->disk()->get($asset->path());
         $pattern = '/(<svg\s+.*?class=".*?)(".*)/';


### PR DESCRIPTION
As I'm sure you know, assets IDs were replaced by URLs in v2.5.0.

FYI: This works perfectly for my usecase - thanks you for sharing it:
- Portfolio site with a global grid field to allow client to add their social media channels
- Grid has an asset field to set an SVG file
- Need to inline the SVG in order to style with CSS (fill colour changes depending on context)