### PR TITLE
Add support for shorthand syntax

### DIFF
--- a/addons/SvgOutput/SvgOutputTags.php
+++ b/addons/SvgOutput/SvgOutputTags.php
@@ -7,19 +7,26 @@ use Statamic\Extend\Tags;
 
 class SvgOutputTags extends Tags
 {
-    public function index()
+    public function __call($name, $args)
     {
-        $asset = Asset::find($this->get('url'));
+        return $this->index(array_get($this->context, $name));
+    }
+
+    public function index($url = null)
+    {
+        $asset = Asset::find($url ?: $this->get('url'));
         $class = $this->get('class');
         $svg = $asset->disk()->get($asset->path());
         $pattern = '/(<svg\s+.*?class=".*?)(".*)/';
         $hasClass = preg_match($pattern, $svg);
+
         // Append class to SVG
         if ($hasClass) {
-          $output = preg_replace($pattern,'$1 '. $class .'$2',$svg);
+            $output = preg_replace($pattern, '$1 '. $class .'$2', $svg);
         } else {
-          $output = str_replace('<svg ', '<svg class="' . $class . '" ', $svg);
+            $output = str_replace('<svg ', '<svg class="' . $class . '" ', $svg);
         }
+
         return $output;
     }
 }

--- a/addons/SvgOutput/meta.yaml
+++ b/addons/SvgOutput/meta.yaml
@@ -1,5 +1,5 @@
 name: SVG Output
-version: 1.0.0
+version: 1.1.0
 description: Render the raw output of an SVG asset by ID.
 url: mike-martin.ca
 developer: Mike Martin


### PR DESCRIPTION
This PR adds support for shorthand syntax, for example: `{{ svg_output:[name] }}`